### PR TITLE
Fix the transaction object to assign the type properly

### DIFF
--- a/src/entities/TransactionV2.php
+++ b/src/entities/TransactionV2.php
@@ -22,7 +22,7 @@ class TransactionV2 extends Entity {
     public function __construct($data)
     {
         $this->id = $data["id"];
-        $this->id = $data["type"];
+        $this->type = $data["type"];
         $this->status = $data["status"];
         $this->description = $data["description"];
         $this->amount = $data["amount"];


### PR DESCRIPTION
Hey guys,

I noticed that the `TransactionV2` object had the class variable `id` assigned to both the transaction ID and the transaction type. Because of this all the transaction object's types were lost.

This pull request fixes that.

Cheers